### PR TITLE
Criação da API local

### DIFF
--- a/src/pages/api/papel-paq.json
+++ b/src/pages/api/papel-paq.json
@@ -1,0 +1,28 @@
+{
+  "content": [
+    {
+      "id": 0,
+      "icone": "",
+      "titulo": "Acolhe e empodera",
+      "texto": "Despertamos os jovem para que eles enxerguem novos futuros possíveis, se sintam pertencentes ao ecossistema tech e se empoderem para ocupar esses espaços."
+    },
+    {
+      "id": 1,
+      "icone": "",
+      "titulo": "Expande a Visão",
+      "texto": "“Só sonhamos com aquilo que conhecemos”. Conectamos os jovens com novos espaços, pessoas e experiências, ampliando sua visão sobre a cultura tech e também sobre o mundo."
+    },
+    {
+      "id": 2,
+      "icone": "",
+      "titulo": "qualifica em tech",
+      "texto": "Fornecemos acesso a infraestrutura de qualidade, cursos, mentorias e também o acompanhamento necessário para o desenvolvolvimento dos jovens até a conquista do sucesso nas principais carreiras  de tecnologia."
+    },
+    {
+      "id": 3,
+      "icone": "",
+      "titulo": "insere no mercado",
+      "texto": "Promovemos mobilidade social através da empregabilidade, conectando os jovens qualificados às vagas em empresas da área de tecnologia."
+    }
+  ]
+}

--- a/src/pages/api/papel-paq.ts
+++ b/src/pages/api/papel-paq.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { content as jsonContent } from "./papel-paq.json";
+
+type ResponseData = {
+  content: typeof jsonContent;
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  res.status(200).json({ content: jsonContent });
+}


### PR DESCRIPTION
## O que foi feito

Foi criada a estrutura para a API local.

## Informações adicionais

A documentação sobre rotas pode ser encontrada [aqui](https://nextjs.org/docs/pages/building-your-application/routing/api-routes).

## Como testar

- Rodar o projeto com `npm run dev`
- No browser acessar a URL `http://localhost:3000/api/papel-paq`
- Verificar se a saída é um JSON válido como este:

![Imagem do WhatsApp de 2024-07-04 à(s) 21 28 16_099307d3](https://github.com/paq-devs/site-paq/assets/2390172/b133a38a-b90b-4559-99d1-ae7feef65c58)
