### PR TITLE
Adiciona menu mobile

### DIFF
--- a/src/app/components/Header/PaqHeader.module.css
+++ b/src/app/components/Header/PaqHeader.module.css
@@ -7,37 +7,6 @@
   font-family: "Poppins Semibold", sans-serif;
 }
 
-.paqDropdown {
-  margin: 0 auto;
-}
-
-.paqDropdown a {
-  display: flex;
-  flex-direction: row;
-  color: #000;
-}
-
-.dropdownContent {
-  position: absolute;
-  background-color: #fff;
-  min-width: 160px;
-  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
-  z-index: 1;
-}
-
-.dropdownContent a {
-  color: black;
-  padding: 12px 16px;
-  text-decoration: none;
-  display: block;
-}
-
-.dropdownContainer {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  justify-content: space-around;
-}
-
 .container .containerButton {
   display: flex;
   justify-content: right;
@@ -51,10 +20,6 @@
   width: 70px;
 }
 
-.hamburger {
-  display: none;
-}
-
 .container .containerButton .buttonDesktop {
   display: block;
 }
@@ -64,18 +29,6 @@
 }
 
 @media screen and (max-width: 768px) {
-  .dropdownContainer {
-    display: none;
-  }
-
-  .hamburger {
-    display: block;
-    font-size: 24px;
-    width: 30px;
-    height: 30px;
-    margin-left: 10px;
-  }
-
   .container {
     display: grid;
     grid-template-columns: repeat(3, 1fr);

--- a/src/app/components/Header/PaqHeader.tsx
+++ b/src/app/components/Header/PaqHeader.tsx
@@ -2,43 +2,16 @@
 import React, { useState } from "react";
 import Image from "next/image";
 import Button from "../button";
-import { FiAlignJustify, FiChevronDown } from "react-icons/fi";
+import Menu from "../Menu/Menu"
 import style from "./PaqHeader.module.css";
 import logoPaq from "./img/logo-paq.png";
 
-const DropdownPaq = ({ text, isOpen, setIsOpen }: any) => {
-  return (
-    <div className={style.paqDropdown}>
-      <a
-        href="#"
-        className={style.dropdownButton}
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        {text}
-        <FiChevronDown />
-      </a>
-      {isOpen && (
-        <div className={style.dropdownContent}>
-          <a href="#quem-somos">Quem somos</a>
-          <a href="#papel-do-paq">Papel do paq</a>
-          <a href="#impaqtometro">Impacto</a>
-        </div>
-      )}
-    </div>
-  );
-};
 
 export default function PaqHeader() {
-  const [isOpen, setIsOpen] = useState(false);
+  
   return (
     <div className={style.container}>
-      <FiAlignJustify className={style.hamburger} />
-      <div className={style.dropdownContainer}>
-        <DropdownPaq text={"Sobre"} isOpen={isOpen} setIsOpen={setIsOpen} />
-        <a href="#como-apoiar">Apoio</a>
-        <a href="#programas-e-espacos">Programas</a>
-        <a href="#historias">Histórias</a>
-      </div>
+      <Menu />
       <div className={style.logo}>
         <Image src={logoPaq} alt="Logo PAQ" />
       </div>

--- a/src/app/components/Menu/Menu.module.css
+++ b/src/app/components/Menu/Menu.module.css
@@ -1,0 +1,69 @@
+.hamburger {
+  display: none;
+}
+
+.mobile_container {
+  position: absolute;
+  top: 64px;
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  width: 100%;
+  background: white;
+  padding-left: 16px;
+  box-shadow: -2px 19px 23px 0px rgba(0,0,0,0.32);
+  z-index: 10;
+  margin-bottom: 16px;
+}
+
+.mobile_menu_item {
+  margin-bottom: 16px
+
+}
+.mobile_submenu_item {
+  padding-left: 32px;
+  margin-bottom: 16px;
+
+}
+
+.paqDropdown a {
+  display: flex;
+  flex-direction: row;
+  color: #000;
+}
+
+.dropdownContent {
+  position: absolute;
+  background-color: #fff;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+}
+
+.dropdownContent a {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+.dropdownContainer {
+  padding-left: 20px;
+  display: flex;
+  gap: 20px;
+}
+
+@media screen and (max-width: 768px) {
+  .dropdownContainer {
+    display: none;
+  }
+
+  .hamburger {
+    display: block;
+    font-size: 24px;
+    width: 30px;
+    height: 30px;
+    margin-left: 10px;
+  }
+}

--- a/src/app/components/Menu/Menu.tsx
+++ b/src/app/components/Menu/Menu.tsx
@@ -54,7 +54,7 @@ const Menu = () => {
         {
           MenuItems.map((item) => {
             if (item.submenu) return <DropdownPaq item={item} />
-            return  <a key={item.label} ref={item.anchor}>{item.label}</a>
+            return  <a key={item.label} href={item.anchor}>{item.label}</a>
           })
         }
       </div>

--- a/src/app/components/Menu/Menu.tsx
+++ b/src/app/components/Menu/Menu.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from "react";
+import { FiAlignJustify, FiChevronDown } from "react-icons/fi";
+import style from "./Menu.module.css";
+import MenuItems, { MenuItem } from "./MenuItems"
+
+const DropdownPaq = ({ item }: ({ item: MenuItem })) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className={style.paqDropdown}>
+      <a
+        href="#"
+        className={style.dropdownButton}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {item.label}
+        <FiChevronDown />
+      </a>
+      {isOpen && (
+        <div className={style.dropdownContent}>
+          {item.submenu?.map((item) => (
+            <a href={item.anchor}>{item.label}</a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+
+const Menu = () => {
+  const [isMobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  return (
+    <>
+      <FiAlignJustify className={style.hamburger} onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}/>
+      {isMobileMenuOpen && 
+        <div className={style.mobile_container}>
+          {MenuItems.map((item : MenuItem) => (
+            <>
+              <a className={style.mobile_menu_item}>{item.label}</a>
+              {item.submenu && (
+                item.submenu.map((submenu) => (
+                  <a className={style.mobile_submenu_item} href={submenu.anchor}>{submenu.label}</a>
+                ))
+              )}
+            </>
+          ))}
+        </div>
+      }
+
+      <div className={style.dropdownContainer}>
+        
+        {
+          MenuItems.map((item) => {
+            if (item.submenu) return <DropdownPaq item={item} />
+            return  <a href={item.anchor}>{item.label}</a>
+          })
+        }
+      </div>
+    </>
+  )
+}
+
+export default Menu

--- a/src/app/components/Menu/Menu.tsx
+++ b/src/app/components/Menu/Menu.tsx
@@ -53,7 +53,7 @@ const Menu = () => {
         
         {
           MenuItems.map((item) => {
-            if (item.submenu) return <DropdownPaq item={item} />
+            if (item.submenu) return <DropdownPaq key={item.label} item={item} />
             return  <a key={item.label} href={item.anchor}>{item.label}</a>
           })
         }

--- a/src/app/components/Menu/Menu.tsx
+++ b/src/app/components/Menu/Menu.tsx
@@ -19,7 +19,7 @@ const DropdownPaq = ({ item }: ({ item: MenuItem })) => {
       {isOpen && (
         <div className={style.dropdownContent}>
           {item.submenu?.map((item) => (
-            <a href={item.anchor}>{item.label}</a>
+            <a key={item.label} href={item.anchor}>{item.label}</a>
           ))}
         </div>
       )}
@@ -41,7 +41,7 @@ const Menu = () => {
               <a className={style.mobile_menu_item}>{item.label}</a>
               {item.submenu && (
                 item.submenu.map((submenu) => (
-                  <a className={style.mobile_submenu_item} href={submenu.anchor}>{submenu.label}</a>
+                  <a key={submenu.label} className={style.mobile_submenu_item} href={submenu.anchor}>{submenu.label}</a>
                 ))
               )}
             </>
@@ -54,7 +54,7 @@ const Menu = () => {
         {
           MenuItems.map((item) => {
             if (item.submenu) return <DropdownPaq item={item} />
-            return  <a href={item.anchor}>{item.label}</a>
+            return  <a key={item.label} ref={item.anchor}>{item.label}</a>
           })
         }
       </div>

--- a/src/app/components/Menu/MenuItems.tsx
+++ b/src/app/components/Menu/MenuItems.tsx
@@ -1,0 +1,39 @@
+export interface MenuItem {
+  label: string;
+  anchor?: string;
+  submenu?: MenuItem[];
+}
+
+const MenuItems : MenuItem[] = [
+  {
+    label: "Sobre",
+    submenu: [
+      {
+        label: "Quem somos",
+        anchor: "#quem-somos"
+      },
+      {
+        label: "Papel do paq",
+        anchor: "#papel-do-paq"
+      },
+      {
+        label: "Impacto",
+        anchor: "#impaqtometro"
+      }
+    ]
+  },
+  {
+    label: "Apoio",
+    anchor: "#como-apoiar"
+  },
+  {
+    label: "Programas",
+    anchor: "#programas-e-espacos"
+  },
+  {
+    label: "Histórias",
+    anchor: "#historias"
+  }
+]
+
+export default MenuItems


### PR DESCRIPTION
Esse PR faz algumas correções de espaçamento na vesão desktop do menu, e também cria uma configuração de menu mobile.
Como não encontrei especificação do menu mobile aberto, criei uma versão simples que pode ser substituída depois, apenas para permitir o funcionamento.

Versão Desktop:
![image](https://github.com/user-attachments/assets/45944a52-4a64-4451-8168-1e3f46ac6b38)


Versão Mobile:
![image](https://github.com/user-attachments/assets/764093c2-7f97-45aa-a26f-f71187554f13)
