### PR TITLE
Remove arrows do slick

### DIFF
--- a/src/app/components/UmFuturoDiversoDesktop/index.tsx
+++ b/src/app/components/UmFuturoDiversoDesktop/index.tsx
@@ -14,6 +14,7 @@ import img03 from "./img/carrossel-03-min.png";
 export default function UmFuturoDiversoDesktop() {
   var settings = {
     dots: false,
+    arrows: false,
     infinite: true,
     autoplay: true,
     autoplaySpeed: 3000,


### PR DESCRIPTION
Percebi que o que causa o scroll horizontal é a seta do slick:

![image](https://github.com/user-attachments/assets/b6c41cc0-ffd3-4db2-8e41-7e3617462c6f)



Esse PR aqui adiciona a prop arrows = false 